### PR TITLE
docs: add firewall documentation and devcontainer comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,16 @@ pypi.org
 files.pythonhosted.org
 ```
 
-### Proxy Support
+### Host Access
 
-When `ANTHROPIC_BASE_URL` points to a local proxy (e.g. `http://host.docker.internal:4141`), the firewall automatically adds a rule allowing traffic to that host and port.
+By default the firewall blocks all traffic to the Docker host. Two levels of access are available:
+
+- **Proxy only (automatic):** When `ANTHROPIC_BASE_URL` points to a local proxy (e.g. `http://host.docker.internal:4141`), the firewall allows traffic to that specific host and port.
+- **Unrestricted:** To allow the agent to reach any service on the Docker host (local databases, dev servers, MCP servers, etc.), create an `allow-host-access` marker:
+
+```bash
+touch agents/<name>/firewall/allow-host-access
+```
 
 ### Other Details
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ pearl-agents/
 │   ├── base/             # Base image: node + claude-cli + git + dumb-init
 │   └── code/             # Code agent: + ruby, python, go, build-essential
 │       ├── firewall/     # Network firewall config (iptables whitelisting)
-│       │   ├── enabled   # Marker file — presence enables firewall
 │       │   └── domains.txt # Agent-specific allowed domains
 │       ├── skills/       # Volume-mounted at /skills (no rebuild needed)
 │       │   ├── CLAUDE.md
@@ -139,20 +138,18 @@ Skills live in `agents/<name>/skills/` and are mounted read-only at `/skills` in
 
 ## Network Firewall
 
-PEARL includes an optional iptables-based network firewall that whitelists allowed domains and blocks all other outbound traffic. This prevents agents from exfiltrating data or reaching unexpected services.
+PEARL includes an iptables-based network firewall that whitelists allowed domains and blocks all other outbound traffic. The firewall is **enabled by default** for all agents — no configuration needed.
 
-### Enabling the Firewall
+If firewall initialization fails, the container **refuses to start** — it will not fall back to an unprotected state.
 
-Create a marker file to enable the firewall for an agent:
+### Disabling the Firewall
+
+To opt out for a specific agent, create a `disabled` marker file:
 
 ```bash
 mkdir -p agents/<name>/firewall
-touch agents/<name>/firewall/enabled
+touch agents/<name>/firewall/disabled
 ```
-
-When `agents/<name>/firewall/enabled` exists, `bin/pearl` adds `--cap-add=NET_ADMIN --cap-add=NET_RAW` and mounts the firewall directory. The entrypoint runs `init-firewall.sh` before launching Claude.
-
-If firewall initialization fails, the container **refuses to start** — it will not fall back to an unprotected state.
 
 ### Core Domains (Always Allowed)
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Every agent with the firewall enabled can reach:
 - `api.anthropic.com` — Claude API
 - `sentry.io` — error reporting
 - `statsig.anthropic.com` / `statsig.com` — feature flags
-- GitHub (`*.github.com`) — IPs fetched dynamically from the [GitHub meta API](https://api.github.com/meta)
+- GitHub — IP ranges fetched dynamically from the [GitHub meta API](https://api.github.com/meta)
 
 DNS (UDP/TCP port 53) and SSH (port 22) are always permitted. Localhost traffic is unrestricted.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Each agent runs in an ephemeral Docker container with scoped credentials, volume-mounted skills, and no host access beyond what's explicitly configured.
 
+> **Coming from the official Claude Code devcontainer?** See [how Pearl compares](docs/comparison-devcontainers.md).
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ pearl-agents/
 ├── agents/
 │   ├── base/             # Base image: node + claude-cli + git + dumb-init
 │   └── code/             # Code agent: + ruby, python, go, build-essential
+│       ├── firewall/     # Network firewall config (iptables whitelisting)
+│       │   ├── enabled   # Marker file — presence enables firewall
+│       │   └── domains.txt # Agent-specific allowed domains
 │       ├── skills/       # Volume-mounted at /skills (no rebuild needed)
 │       │   ├── CLAUDE.md
 │       │   └── references/
@@ -58,7 +61,7 @@ pearl-agents/
 
 ```
 node:22-bookworm-slim
-  └── pearl-base          # claude-cli, git, dumb-init, ripgrep, jq
+  └── pearl-base          # claude-cli, git, dumb-init, ripgrep, jq, iptables
         └── pearl-code    # ruby, python, go, build-essential, shellcheck
         └── pearl-pptx    # (future) libreoffice, python-pptx
 ```
@@ -133,6 +136,54 @@ Existing monolithic agent env files (with auth + git + token in one file) still 
 Skills live in `agents/<name>/skills/` and are mounted read-only at `/skills` in the container. The entrypoint symlinks `/skills/CLAUDE.md` into `/workspace/CLAUDE.md` so Claude picks it up automatically.
 
 **Edit skills without rebuilding the image** — changes take effect on the next `bin/pearl` invocation.
+
+## Network Firewall
+
+PEARL includes an optional iptables-based network firewall that whitelists allowed domains and blocks all other outbound traffic. This prevents agents from exfiltrating data or reaching unexpected services.
+
+### Enabling the Firewall
+
+Create a marker file to enable the firewall for an agent:
+
+```bash
+mkdir -p agents/<name>/firewall
+touch agents/<name>/firewall/enabled
+```
+
+When `agents/<name>/firewall/enabled` exists, `bin/pearl` adds `--cap-add=NET_ADMIN --cap-add=NET_RAW` and mounts the firewall directory. The entrypoint runs `init-firewall.sh` before launching Claude.
+
+If firewall initialization fails, the container **refuses to start** — it will not fall back to an unprotected state.
+
+### Core Domains (Always Allowed)
+
+Every agent with the firewall enabled can reach:
+
+- `registry.npmjs.org` — npm packages
+- `api.anthropic.com` — Claude API
+- `sentry.io` — error reporting
+- `statsig.anthropic.com` / `statsig.com` — feature flags
+- GitHub (`*.github.com`) — IPs fetched dynamically from the [GitHub meta API](https://api.github.com/meta)
+
+DNS (UDP/TCP port 53) and SSH (port 22) are always permitted. Localhost traffic is unrestricted.
+
+### Per-Agent Domains
+
+Add agent-specific domains to `agents/<name>/firewall/domains.txt` (one domain per line, `#` comments supported):
+
+```
+# Example: allow PyPI for pip installs
+pypi.org
+files.pythonhosted.org
+```
+
+### Proxy Support
+
+When `ANTHROPIC_BASE_URL` points to a local proxy (e.g. `http://host.docker.internal:4141`), the firewall automatically adds a rule allowing traffic to that host and port.
+
+### Other Details
+
+- **IPv6** is blocked entirely (all policies set to DROP).
+- **Verification**: on startup the firewall self-tests by confirming `example.com` is blocked and `api.github.com` is reachable. If either check fails, the container exits.
 
 ## Development
 

--- a/agents/base/Dockerfile
+++ b/agents/base/Dockerfile
@@ -17,7 +17,7 @@ RUN git config --system credential.https://github.com.helper \
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --chmod=755 init-firewall.sh /usr/local/bin/init-firewall.sh
 
-RUN echo "agent ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/firewall \
+RUN echo "agent ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh, /usr/sbin/iptables" > /etc/sudoers.d/firewall \
   && chmod 440 /etc/sudoers.d/firewall
 
 RUN useradd -m -s /bin/bash agent

--- a/agents/base/entrypoint.sh
+++ b/agents/base/entrypoint.sh
@@ -28,12 +28,15 @@ if [[ -f /tools/.mcp.json ]]; then
 fi
 
 # Initialize firewall (enabled by default, opt out with /firewall/disabled)
-# Requires NET_ADMIN capability — skip gracefully when not present (e.g. CI smoke tests)
-if [[ ! -f /firewall/disabled ]] && sudo iptables -L -n >/dev/null 2>&1; then
-  echo "Initializing network firewall..." >&2
-  if ! sudo /usr/local/bin/init-firewall.sh; then
-    echo "Error: Firewall initialization failed. Refusing to start without network security." >&2
-    exit 1
+if [[ ! -f /firewall/disabled ]]; then
+  if sudo iptables -L -n >/dev/null 2>&1; then
+    echo "Initializing network firewall..." >&2
+    if ! sudo /usr/local/bin/init-firewall.sh; then
+      echo "Error: Firewall initialization failed. Refusing to start without network security." >&2
+      exit 1
+    fi
+  else
+    echo "Warning: iptables not available (missing NET_ADMIN?) — starting WITHOUT network firewall" >&2
   fi
 fi
 

--- a/agents/base/entrypoint.sh
+++ b/agents/base/entrypoint.sh
@@ -28,7 +28,8 @@ if [[ -f /tools/.mcp.json ]]; then
 fi
 
 # Initialize firewall (enabled by default, opt out with /firewall/disabled)
-if [[ ! -f /firewall/disabled ]]; then
+# Requires NET_ADMIN capability — skip gracefully when not present (e.g. CI smoke tests)
+if [[ ! -f /firewall/disabled ]] && sudo iptables -L -n >/dev/null 2>&1; then
   echo "Initializing network firewall..." >&2
   if ! sudo /usr/local/bin/init-firewall.sh; then
     echo "Error: Firewall initialization failed. Refusing to start without network security." >&2

--- a/agents/base/entrypoint.sh
+++ b/agents/base/entrypoint.sh
@@ -27,8 +27,8 @@ if [[ -f /tools/.mcp.json ]]; then
   ln -sf /tools/.mcp.json /workspace/.mcp.json
 fi
 
-# Initialize firewall if enabled for this agent
-if [[ -f /firewall/enabled ]]; then
+# Initialize firewall (enabled by default, opt out with /firewall/disabled)
+if [[ ! -f /firewall/disabled ]]; then
   echo "Initializing network firewall..." >&2
   if ! sudo /usr/local/bin/init-firewall.sh; then
     echo "Error: Firewall initialization failed. Refusing to start without network security." >&2

--- a/agents/base/init-firewall.sh
+++ b/agents/base/init-firewall.sh
@@ -138,16 +138,18 @@ else
   if [[ -n "$PROXY_URL" ]]; then
     # Extract host and port from URL (e.g. http://localhost:4141 or http://host.docker.internal:4141)
     PROXY_HOST=$(echo "$PROXY_URL" | sed -E 's|https?://([^:/]+).*|\1|')
-    PROXY_PORT=$(echo "$PROXY_URL" | sed -E 's|.*:([0-9]+).*|\1|')
+    PROXY_PORT=$(echo "$PROXY_URL" | sed -nE 's|https?://[^/]*:([0-9]+).*|\1|p')
 
     # Only add rule if it points to a local host
     if [[ "$PROXY_HOST" == "localhost" || "$PROXY_HOST" == "127.0.0.1" || "$PROXY_HOST" == "host.docker.internal" ]]; then
-      if [[ "$PROXY_PORT" =~ ^[0-9]+$ ]]; then
+      if [[ -n "$PROXY_PORT" && "$PROXY_PORT" =~ ^[0-9]+$ ]]; then
         iptables -A INPUT -s "$HOST_IP" -p tcp --sport "$PROXY_PORT" -m state --state ESTABLISHED -j ACCEPT
         iptables -A OUTPUT -d "$HOST_IP" -p tcp --dport "$PROXY_PORT" -j ACCEPT
         log "Proxy exception added: $HOST_IP:$PROXY_PORT (ANTHROPIC_BASE_URL=$PROXY_HOST:$PROXY_PORT)"
       else
-        log "WARNING: Could not parse port from ANTHROPIC_BASE_URL='$PROXY_URL' (expected http://host:PORT) — host network access not granted"
+        log "ERROR: Could not parse port from ANTHROPIC_BASE_URL='$PROXY_URL' (expected http://host:PORT)"
+        log "ERROR: The local proxy will be blocked by the firewall. Refusing to start."
+        exit 1
       fi
     else
       log "ANTHROPIC_BASE_URL points to remote host ($PROXY_HOST) — no host network exception needed"
@@ -171,11 +173,15 @@ iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
 # ── Block IPv6 entirely ─────────────────────────────────────────────
-ip6tables -P INPUT DROP 2>/dev/null || true
-ip6tables -P FORWARD DROP 2>/dev/null || true
-ip6tables -P OUTPUT DROP 2>/dev/null || true
-ip6tables -A INPUT -i lo -j ACCEPT 2>/dev/null || true
-ip6tables -A OUTPUT -o lo -j ACCEPT 2>/dev/null || true
+if ip6tables -P INPUT DROP 2>/dev/null; then
+  ip6tables -P FORWARD DROP
+  ip6tables -P OUTPUT DROP
+  ip6tables -A INPUT -i lo -j ACCEPT
+  ip6tables -A OUTPUT -o lo -j ACCEPT
+  log "IPv6 blocked (all policies DROP)"
+else
+  log "WARNING: ip6tables not available — IPv6 traffic is NOT blocked"
+fi
 
 # ── Verification ────────────────────────────────────────────────────
 log "Verifying firewall rules..."

--- a/agents/base/init-firewall.sh
+++ b/agents/base/init-firewall.sh
@@ -117,8 +117,6 @@ for domain in "${ALL_DOMAINS[@]}"; do
 done
 
 # ── Host network access ────────────────────────────────────────────
-# Only allow host access when a local proxy is configured via ANTHROPIC_BASE_URL.
-# We allow only the specific port to prevent access to other host services.
 HOST_IP=$(ip route show default | awk '/^default via/ {print $3; exit}')
 if [[ -z "$HOST_IP" ]]; then
   log "ERROR: Failed to detect host IP from 'ip route show default'"
@@ -129,23 +127,31 @@ if [[ ! "$HOST_IP" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
   exit 1
 fi
 
-PROXY_URL="${ANTHROPIC_BASE_URL:-}"
-if [[ -n "$PROXY_URL" ]]; then
-  # Extract host and port from URL (e.g. http://localhost:4141 or http://host.docker.internal:4141)
-  PROXY_HOST=$(echo "$PROXY_URL" | sed -E 's|https?://([^:/]+).*|\1|')
-  PROXY_PORT=$(echo "$PROXY_URL" | sed -E 's|.*:([0-9]+).*|\1|')
+# Unrestricted host access (opt-in via marker file)
+if [[ -f /firewall/allow-host-access ]]; then
+  iptables -A INPUT -s "$HOST_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
+  iptables -A OUTPUT -d "$HOST_IP" -j ACCEPT
+  log "Unrestricted host access enabled ($HOST_IP)"
+else
+  # Only allow the specific proxy port when ANTHROPIC_BASE_URL points to a local host
+  PROXY_URL="${ANTHROPIC_BASE_URL:-}"
+  if [[ -n "$PROXY_URL" ]]; then
+    # Extract host and port from URL (e.g. http://localhost:4141 or http://host.docker.internal:4141)
+    PROXY_HOST=$(echo "$PROXY_URL" | sed -E 's|https?://([^:/]+).*|\1|')
+    PROXY_PORT=$(echo "$PROXY_URL" | sed -E 's|.*:([0-9]+).*|\1|')
 
-  # Only add rule if it points to a local host
-  if [[ "$PROXY_HOST" == "localhost" || "$PROXY_HOST" == "127.0.0.1" || "$PROXY_HOST" == "host.docker.internal" ]]; then
-    if [[ "$PROXY_PORT" =~ ^[0-9]+$ ]]; then
-      iptables -A INPUT -s "$HOST_IP" -p tcp --sport "$PROXY_PORT" -m state --state ESTABLISHED -j ACCEPT
-      iptables -A OUTPUT -d "$HOST_IP" -p tcp --dport "$PROXY_PORT" -j ACCEPT
-      log "Proxy exception added: $HOST_IP:$PROXY_PORT (ANTHROPIC_BASE_URL=$PROXY_HOST:$PROXY_PORT)"
+    # Only add rule if it points to a local host
+    if [[ "$PROXY_HOST" == "localhost" || "$PROXY_HOST" == "127.0.0.1" || "$PROXY_HOST" == "host.docker.internal" ]]; then
+      if [[ "$PROXY_PORT" =~ ^[0-9]+$ ]]; then
+        iptables -A INPUT -s "$HOST_IP" -p tcp --sport "$PROXY_PORT" -m state --state ESTABLISHED -j ACCEPT
+        iptables -A OUTPUT -d "$HOST_IP" -p tcp --dport "$PROXY_PORT" -j ACCEPT
+        log "Proxy exception added: $HOST_IP:$PROXY_PORT (ANTHROPIC_BASE_URL=$PROXY_HOST:$PROXY_PORT)"
+      else
+        log "WARNING: Could not parse port from ANTHROPIC_BASE_URL='$PROXY_URL' (expected http://host:PORT) — host network access not granted"
+      fi
     else
-      log "WARNING: Could not parse port from ANTHROPIC_BASE_URL='$PROXY_URL' (expected http://host:PORT) — host network access not granted"
+      log "ANTHROPIC_BASE_URL points to remote host ($PROXY_HOST) — no host network exception needed"
     fi
-  else
-    log "ANTHROPIC_BASE_URL points to remote host ($PROXY_HOST) — no host network exception needed"
   fi
 fi
 

--- a/bin/pearl
+++ b/bin/pearl
@@ -245,11 +245,11 @@ TOOLS_DIR="$AGENTS_REPO/agents/$AGENT/tools"
 [[ -n "${PEARL_OUTPUT:-}" ]] && \
   DOCKER_ARGS+=(-v "$PEARL_OUTPUT:/pearl-output")
 
-# Firewall support
+# Firewall support (enabled by default, opt out with firewall/disabled)
 FIREWALL_DIR="$AGENTS_REPO/agents/$AGENT/firewall"
-if [[ -f "$FIREWALL_DIR/enabled" ]]; then
+if [[ ! -f "$FIREWALL_DIR/disabled" ]]; then
   DOCKER_ARGS+=(--cap-add=NET_ADMIN --cap-add=NET_RAW)
-  DOCKER_ARGS+=(-v "$FIREWALL_DIR:/firewall:ro")
+  [[ -d "$FIREWALL_DIR" ]] && DOCKER_ARGS+=(-v "$FIREWALL_DIR:/firewall:ro")
 fi
 
 # Mount current directory as workspace

--- a/docs/comparison-devcontainers.md
+++ b/docs/comparison-devcontainers.md
@@ -16,7 +16,7 @@ Both Pearl and the [official Claude Code devcontainer](https://github.com/anthro
 | Configuration | `.devcontainer/devcontainer.json` | `agents/<name>/` + `~/.config/pearl/` |
 | IDE integration | VS Code required | None (CLI-native) |
 | Base image | `node:20` | `node:22-bookworm-slim` |
-| Shell | zsh + Powerlevel10k | bash (minimal) |
+| Shell | zsh (with p10k theme) | bash (minimal) |
 | User | `node` | `agent` |
 
 ## Security Model
@@ -28,7 +28,7 @@ Both Pearl and the [official Claude Code devcontainer](https://github.com/anthro
 | Per-agent domain whitelist | No (single domain list) | Yes (`agents/<name>/firewall/domains.txt`) |
 | Host network access | Entire `/24` subnet open | Blocked by default; proxy-port-only or opt-in via `allow-host-access` |
 | IPv6 | Not blocked | Blocked (all policies DROP) |
-| Permission mode | `--dangerously-skip-permissions` (user choice) | `--dangerously-skip-permissions` |
+| Permission mode | `--dangerously-skip-permissions` (user choice) | `--dangerously-skip-permissions` (always on) |
 | Credential isolation | VS Code manages | Auth profiles (`pearl auth`) |
 | GitHub token | Environment variable | Environment variable via agent env file |
 

--- a/docs/comparison-devcontainers.md
+++ b/docs/comparison-devcontainers.md
@@ -1,0 +1,80 @@
+# Pearl Agents vs Claude Code Devcontainer
+
+Both Pearl and the [official Claude Code devcontainer](https://github.com/anthropics/claude-code/tree/main/.devcontainer) run Claude Code inside Docker containers with network-level security. This document explains how they differ and when to use which.
+
+## Overview
+
+- **Devcontainer**: VS Code-integrated, single-container sandbox maintained by Anthropic. You open a project in VS Code, it builds the container, and you interact with Claude through the VS Code extension.
+- **Pearl**: CLI-driven, multi-agent framework. Each agent has its own image, firewall rules, auth config, skills, and tools. You interact via `bin/pearl <agent>` from the terminal.
+
+## Architecture
+
+| Aspect | Devcontainer | Pearl Agents |
+|--------|-------------|--------------|
+| Runtime | VS Code Dev Container | Standalone Docker via `bin/pearl` |
+| Agent model | Single container | Multiple named agents (`code`, `pptx`, etc.) |
+| Configuration | `.devcontainer/devcontainer.json` | `agents/<name>/` + `~/.config/pearl/` |
+| IDE integration | VS Code required | None (CLI-native) |
+| Base image | `node:20` | `node:22-bookworm-slim` |
+| Shell | zsh + Powerlevel10k | bash (minimal) |
+| User | `node` | `agent` |
+
+## Security Model
+
+| Feature | Devcontainer | Pearl Agents |
+|---------|-------------|--------------|
+| Network firewall | Always on | Enabled by default, opt-out per agent |
+| Core whitelisted domains | npm, Anthropic, Sentry, Statsig, GitHub, **VS Code Marketplace** | npm, Anthropic, Sentry, Statsig, GitHub |
+| Per-agent domain whitelist | No (single domain list) | Yes (`agents/<name>/firewall/domains.txt`) |
+| Host network access | Entire `/24` subnet open | Blocked by default; proxy-port-only or opt-in via `allow-host-access` |
+| IPv6 | Not blocked | Blocked (all policies DROP) |
+| Permission mode | `--dangerously-skip-permissions` (user choice) | `--dangerously-skip-permissions` |
+| Credential isolation | VS Code manages | Auth profiles (`pearl auth`) |
+| GitHub token | Environment variable | Environment variable via agent env file |
+
+Notable differences:
+
+- The devcontainer opens the entire host `/24` subnet (`HOST_IP.0/24`), giving the container access to all services on the host network. Pearl blocks host access by default and only opens the specific proxy port when `ANTHROPIC_BASE_URL` is set, or all host traffic when `allow-host-access` is opted into.
+- The devcontainer whitelists VS Code Marketplace domains (`marketplace.visualstudio.com`, `vscode.blob.core.windows.net`, `update.code.visualstudio.com`). Pearl omits these since it doesn't use VS Code.
+- Pearl blocks IPv6 entirely; the devcontainer does not.
+
+## Features
+
+| Feature | Devcontainer | Pearl Agents |
+|---------|-------------|--------------|
+| Skills (CLAUDE.md) | Baked into image | Volume-mounted per agent (edit without rebuilding) |
+| MCP tools | Baked into image | Volume-mounted per agent |
+| Persistent state | Docker volume | `~/.config/pearl/state/<agent>/` |
+| Setup wizard | Manual | `pearl setup <agent>` |
+| Multi-auth | No | `pearl auth` profiles (keychain, proxy, API key) |
+| Host settings sync | No | Auto-syncs statusLine, syntax highlighting, thinking mode |
+| CI testing | No | `bin/test-agent` + GitHub Actions |
+| Firewall customization | Edit the script | Marker files + `domains.txt` per agent |
+
+## When to Use Which
+
+**Use the devcontainer when:**
+
+- You primarily use VS Code
+- You want Anthropic's maintained, opinionated setup
+- You need a single-agent workflow
+- You want VS Code extensions (ESLint, Prettier, GitLens) pre-configured
+
+**Use Pearl when:**
+
+- You prefer CLI-driven workflows
+- You need multiple agents with different toolchains (code, presentations, etc.)
+- You want per-agent firewall and auth configuration
+- You want to iterate on skills and tools without rebuilding images
+- You're building automation pipelines
+
+## How Pearl Extends the Devcontainer Approach
+
+Pearl was inspired by the devcontainer's firewall design (the `init-firewall.sh` scripts share a common lineage) but diverges in several ways:
+
+1. **Multi-agent architecture** -- not one container fits all. Each agent gets its own image, skills, tools, and firewall rules.
+2. **Auth profiles** -- support for multiple auth methods (macOS Keychain, proxy, direct API key) switchable per-run.
+3. **Volume-mounted skills/tools** -- iterate without rebuilding Docker images.
+4. **Tighter host network controls** -- block host access by default instead of opening the entire subnet.
+5. **IPv6 coverage** -- block IPv6 to prevent firewall bypass.
+6. **Setup wizard** -- guided onboarding via `pearl setup`.


### PR DESCRIPTION
## Summary
- Add a **Network Firewall** section to the README covering enablement, core/per-agent domains, host access, proxy support, IPv6 blocking, and startup verification
- Update architecture tree and image layers to reflect firewall additions
- Make the firewall **opt-out** instead of opt-in (enabled by default for all agents)
- Add `allow-host-access` marker file for unrestricted Docker host access
- Add `docs/comparison-devcontainers.md` comparing Pearl to the official Claude Code devcontainer (closes #3)

## Test plan
- [ ] Verify documented behavior matches `agents/base/init-firewall.sh` and `bin/pearl` implementation
- [ ] Confirm README and comparison doc render correctly on GitHub