### PR TITLE
fix: exclude GitHub Pages from firewall and harden sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Every agent with the firewall enabled can reach:
 - `api.anthropic.com` — Claude API
 - `sentry.io` — error reporting
 - `statsig.anthropic.com` / `statsig.com` — feature flags
-- GitHub — IP ranges from the [GitHub meta API](https://api.github.com/meta), excluding the `/22` ranges that overlap with GitHub Pages
+- GitHub — IP ranges from the [GitHub meta API](https://api.github.com/meta) (`.web` + `.api` + `.git`), excluding two `/22` ranges that also contain GitHub Pages IPs
 
 DNS (UDP/TCP port 53) and SSH (port 22) are always permitted. Localhost traffic is unrestricted.
 

--- a/README.md
+++ b/README.md
@@ -157,11 +157,12 @@ touch agents/<name>/firewall/disabled
 
 Every agent with the firewall enabled can reach:
 
+- `raw.githubusercontent.com` / `objects.githubusercontent.com` — GitHub content (resolved via DNS)
 - `registry.npmjs.org` — npm packages
 - `api.anthropic.com` — Claude API
 - `sentry.io` — error reporting
 - `statsig.anthropic.com` / `statsig.com` — feature flags
-- GitHub — IP ranges fetched dynamically from the [GitHub meta API](https://api.github.com/meta)
+- GitHub — IP ranges from the [GitHub meta API](https://api.github.com/meta), excluding the `/22` ranges that overlap with GitHub Pages
 
 DNS (UDP/TCP port 53) and SSH (port 22) are always permitted. Localhost traffic is unrestricted.
 

--- a/agents/base/Dockerfile
+++ b/agents/base/Dockerfile
@@ -17,7 +17,10 @@ RUN git config --system credential.https://github.com.helper \
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --chmod=755 init-firewall.sh /usr/local/bin/init-firewall.sh
 
-RUN echo "agent ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh, /usr/sbin/iptables" > /etc/sudoers.d/firewall \
+RUN printf '%s\n' \
+      'Defaults env_keep += "ANTHROPIC_BASE_URL"' \
+      'agent ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh' \
+      > /etc/sudoers.d/firewall \
   && chmod 440 /etc/sudoers.d/firewall
 
 RUN useradd -m -s /bin/bash agent

--- a/agents/base/entrypoint.sh
+++ b/agents/base/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 
 # Initialize firewall (enabled by default, opt out with /firewall/disabled)
 if [[ ! -f /firewall/disabled ]]; then
-  if sudo iptables -L -n >/dev/null 2>&1; then
+  if sudo /usr/local/bin/init-firewall.sh --check 2>/dev/null; then
     echo "Initializing network firewall..." >&2
     if ! sudo /usr/local/bin/init-firewall.sh; then
       echo "Error: Firewall initialization failed. Refusing to start without network security." >&2

--- a/agents/base/entrypoint.sh
+++ b/agents/base/entrypoint.sh
@@ -29,14 +29,20 @@ fi
 
 # Initialize firewall (enabled by default, opt out with /firewall/disabled)
 if [[ ! -f /firewall/disabled ]]; then
-  if sudo /usr/local/bin/init-firewall.sh --check 2>/dev/null; then
+  check_output=$(sudo /usr/local/bin/init-firewall.sh --check 2>&1)
+  check_exit=$?
+  if [[ $check_exit -eq 0 ]]; then
     echo "Initializing network firewall..." >&2
     if ! sudo /usr/local/bin/init-firewall.sh; then
       echo "Error: Firewall initialization failed. Refusing to start without network security." >&2
       exit 1
     fi
+  elif echo "$check_output" | grep -qi "iptables\|permission denied\|Operation not permitted"; then
+    echo "Warning: iptables not available (missing NET_ADMIN capability) — starting WITHOUT network firewall" >&2
   else
-    echo "Warning: iptables not available (missing NET_ADMIN?) — starting WITHOUT network firewall" >&2
+    echo "Error: Firewall capability check failed unexpectedly (exit $check_exit): $check_output" >&2
+    echo "Error: Refusing to start without confirming firewall capability." >&2
+    exit 1
   fi
 fi
 

--- a/agents/base/init-firewall.sh
+++ b/agents/base/init-firewall.sh
@@ -8,6 +8,12 @@ IFS=$'\n\t'
 
 log() { echo "[firewall] $*" >&2; }
 
+# Quick capability check — entrypoint uses this to test if iptables is available
+if [[ "${1:-}" == "--check" ]]; then
+  iptables -L -n >/dev/null 2>&1
+  exit $?
+fi
+
 # ── Preserve Docker DNS before flushing ─────────────────────────────
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
@@ -51,13 +57,17 @@ iptables -A OUTPUT -o lo -j ACCEPT
 ipset create allowed-domains hash:net
 
 # ── GitHub IPs (dynamic via API) ────────────────────────────────────
+# Two /22 ranges (185.199.108.0/22, 192.30.252.0/22) are excluded because they
+# also cover GitHub Pages IPs — any Pages-hosted site would pass the firewall.
+# Domains in those ranges (raw.githubusercontent.com, etc.) are resolved via
+# DNS below instead.
 log "Fetching GitHub IP ranges..."
 gh_ranges=$(curl -sf https://api.github.com/meta) || {
   log "ERROR: Failed to fetch GitHub IP ranges"
   exit 1
 }
 
-if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+if ! echo "$gh_ranges" | jq -e '.api and .git' >/dev/null; then
   log "ERROR: GitHub API response missing required fields"
   exit 1
 fi
@@ -69,11 +79,19 @@ while read -r cidr; do
     exit 1
   fi
   ipset add allowed-domains "$cidr"
-done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+done < <(echo "$gh_ranges" | jq -r '
+  [(.api + .git)[] | select(test("^[0-9.]+/"))] | unique
+  | map(select(. != "185.199.108.0/22" and . != "192.30.252.0/22"))
+  | .[]' | aggregate -q)
 
 # ── Core whitelist (all agents) ─────────────────────────────────────
 CORE_DOMAINS=(
+  # GitHub domains whose IPs fall in the excluded /22 ranges (see above)
+  "raw.githubusercontent.com"
+  "objects.githubusercontent.com"
+  # npm
   "registry.npmjs.org"
+  # Claude / Anthropic
   "api.anthropic.com"
   "sentry.io"
   "statsig.anthropic.com"
@@ -129,9 +147,17 @@ fi
 
 # Unrestricted host access (opt-in via marker file)
 if [[ -f /firewall/allow-host-access ]]; then
+  # Allow both the container gateway and host.docker.internal (may differ on Docker Desktop)
   iptables -A INPUT -s "$HOST_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
   iptables -A OUTPUT -d "$HOST_IP" -j ACCEPT
-  log "Unrestricted host access enabled ($HOST_IP)"
+  HDI_IP=$(getent ahosts host.docker.internal 2>/dev/null | awk '$2 == "STREAM" {print $1; exit}')
+  if [[ -n "$HDI_IP" && "$HDI_IP" != "$HOST_IP" ]]; then
+    iptables -A INPUT -s "$HDI_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
+    iptables -A OUTPUT -d "$HDI_IP" -j ACCEPT
+    log "Unrestricted host access enabled ($HOST_IP + $HDI_IP)"
+  else
+    log "Unrestricted host access enabled ($HOST_IP)"
+  fi
 else
   # Only allow the specific proxy port when ANTHROPIC_BASE_URL points to a local host
   PROXY_URL="${ANTHROPIC_BASE_URL:-}"
@@ -143,9 +169,14 @@ else
     # Only add rule if it points to a local host
     if [[ "$PROXY_HOST" == "localhost" || "$PROXY_HOST" == "127.0.0.1" || "$PROXY_HOST" == "host.docker.internal" ]]; then
       if [[ -n "$PROXY_PORT" && "$PROXY_PORT" =~ ^[0-9]+$ ]]; then
-        iptables -A INPUT -s "$HOST_IP" -p tcp --sport "$PROXY_PORT" -m state --state ESTABLISHED -j ACCEPT
-        iptables -A OUTPUT -d "$HOST_IP" -p tcp --dport "$PROXY_PORT" -j ACCEPT
-        log "Proxy exception added: $HOST_IP:$PROXY_PORT (ANTHROPIC_BASE_URL=$PROXY_HOST:$PROXY_PORT)"
+        # Resolve the proxy hostname to its actual IP — on Docker Desktop for Mac,
+        # host.docker.internal (192.168.65.x) differs from the container gateway
+        # (172.17.0.1), so we can't use HOST_IP from the default route.
+        PROXY_IP=$(getent ahosts "$PROXY_HOST" 2>/dev/null | awk '$2 == "STREAM" {print $1; exit}')
+        [[ -z "$PROXY_IP" ]] && PROXY_IP="$HOST_IP"
+        iptables -A INPUT -s "$PROXY_IP" -p tcp --sport "$PROXY_PORT" -m state --state ESTABLISHED -j ACCEPT
+        iptables -A OUTPUT -d "$PROXY_IP" -p tcp --dport "$PROXY_PORT" -j ACCEPT
+        log "Proxy exception added: $PROXY_IP:$PROXY_PORT (ANTHROPIC_BASE_URL=$PROXY_HOST:$PROXY_PORT)"
       else
         log "ERROR: Could not parse port from ANTHROPIC_BASE_URL='$PROXY_URL' (expected http://host:PORT)"
         log "ERROR: The local proxy will be blocked by the firewall. Refusing to start."

--- a/agents/base/init-firewall.sh
+++ b/agents/base/init-firewall.sh
@@ -8,10 +8,19 @@ IFS=$'\n\t'
 
 log() { echo "[firewall] $*" >&2; }
 
-# Quick capability check — entrypoint uses this to test if iptables is available
+# Quick capability check — routed through this script so only
+# init-firewall.sh needs to be in the sudoers allowlist.
 if [[ "${1:-}" == "--check" ]]; then
   iptables -L -n >/dev/null 2>&1
   exit $?
+fi
+
+# Prevent re-invocation — an agent could re-run this script with a crafted
+# ANTHROPIC_BASE_URL to open extra host ports.
+LOCK_FILE="/var/run/firewall-initialized"
+if [[ -f "$LOCK_FILE" ]]; then
+  log "ERROR: Firewall already initialized. Re-initialization is not permitted."
+  exit 1
 fi
 
 # ── Preserve Docker DNS before flushing ─────────────────────────────
@@ -67,31 +76,44 @@ gh_ranges=$(curl -sf https://api.github.com/meta) || {
   exit 1
 }
 
-if ! echo "$gh_ranges" | jq -e '.api and .git' >/dev/null; then
-  log "ERROR: GitHub API response missing required fields"
+if ! echo "$gh_ranges" | jq -e '(.web | type == "array" and length > 0) and (.api | type == "array" and length > 0) and (.git | type == "array" and length > 0)' >/dev/null; then
+  log "ERROR: GitHub API response missing or malformed .web/.api/.git fields"
   exit 1
 fi
 
 log "Processing GitHub IPs..."
+github_cidrs=$(echo "$gh_ranges" | jq -r '
+  [(.web + .api + .git)[] | select(test("^[0-9.]+/"))] | unique
+  | map(select(. != "185.199.108.0/22" and . != "192.30.252.0/22"))
+  | .[]') || {
+  log "ERROR: Failed to extract CIDR ranges from GitHub API response"
+  exit 1
+}
+github_cidrs=$(echo "$github_cidrs" | aggregate -q) || {
+  log "ERROR: aggregate failed to process GitHub CIDR ranges"
+  exit 1
+}
+if [[ -z "$github_cidrs" ]]; then
+  log "ERROR: No IPv4 CIDR ranges found in GitHub API response after filtering"
+  exit 1
+fi
 while read -r cidr; do
   if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
     log "ERROR: Invalid CIDR range from GitHub meta: $cidr"
     exit 1
   fi
   ipset add allowed-domains "$cidr"
-done < <(echo "$gh_ranges" | jq -r '
-  [(.api + .git)[] | select(test("^[0-9.]+/"))] | unique
-  | map(select(. != "185.199.108.0/22" and . != "192.30.252.0/22"))
-  | .[]' | aggregate -q)
+done <<< "$github_cidrs"
 
 # ── Core whitelist (all agents) ─────────────────────────────────────
 CORE_DOMAINS=(
-  # GitHub domains whose IPs fall in the excluded /22 ranges (see above)
+  # GitHub content domains — their IPs currently fall in the excluded /22
+  # ranges, so they must be resolved individually via DNS
   "raw.githubusercontent.com"
   "objects.githubusercontent.com"
   # npm
   "registry.npmjs.org"
-  # Claude / Anthropic
+  # Claude CLI dependencies
   "api.anthropic.com"
   "sentry.io"
   "statsig.anthropic.com"
@@ -150,12 +172,13 @@ if [[ -f /firewall/allow-host-access ]]; then
   # Allow both the container gateway and host.docker.internal (may differ on Docker Desktop)
   iptables -A INPUT -s "$HOST_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
   iptables -A OUTPUT -d "$HOST_IP" -j ACCEPT
-  HDI_IP=$(getent ahosts host.docker.internal 2>/dev/null | awk '$2 == "STREAM" {print $1; exit}')
-  if [[ -n "$HDI_IP" && "$HDI_IP" != "$HOST_IP" ]]; then
+  HDI_IP=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '$2 == "STREAM" {print $1; exit}')
+  if [[ -n "$HDI_IP" && "$HDI_IP" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ && "$HDI_IP" != "$HOST_IP" ]]; then
     iptables -A INPUT -s "$HDI_IP" -m state --state ESTABLISHED,RELATED -j ACCEPT
     iptables -A OUTPUT -d "$HDI_IP" -j ACCEPT
     log "Unrestricted host access enabled ($HOST_IP + $HDI_IP)"
   else
+    [[ -z "$HDI_IP" ]] && log "WARNING: host.docker.internal could not be resolved — only gateway IP whitelisted"
     log "Unrestricted host access enabled ($HOST_IP)"
   fi
 else
@@ -172,8 +195,15 @@ else
         # Resolve the proxy hostname to its actual IP — on Docker Desktop for Mac,
         # host.docker.internal (192.168.65.x) differs from the container gateway
         # (172.17.0.1), so we can't use HOST_IP from the default route.
-        PROXY_IP=$(getent ahosts "$PROXY_HOST" 2>/dev/null | awk '$2 == "STREAM" {print $1; exit}')
-        [[ -z "$PROXY_IP" ]] && PROXY_IP="$HOST_IP"
+        PROXY_IP=$(getent ahostsv4 "$PROXY_HOST" 2>/dev/null | awk '$2 == "STREAM" {print $1; exit}')
+        if [[ -z "$PROXY_IP" ]]; then
+          log "WARNING: Could not resolve $PROXY_HOST via getent, falling back to gateway $HOST_IP"
+          PROXY_IP="$HOST_IP"
+        fi
+        if [[ ! "$PROXY_IP" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          log "ERROR: Resolved proxy IP '$PROXY_IP' is not a valid IPv4 address"
+          exit 1
+        fi
         iptables -A INPUT -s "$PROXY_IP" -p tcp --sport "$PROXY_PORT" -m state --state ESTABLISHED -j ACCEPT
         iptables -A OUTPUT -d "$PROXY_IP" -p tcp --dport "$PROXY_PORT" -j ACCEPT
         log "Proxy exception added: $PROXY_IP:$PROXY_PORT (ANTHROPIC_BASE_URL=$PROXY_HOST:$PROXY_PORT)"
@@ -231,3 +261,6 @@ log "Allowed domain (api.github.com) correctly accessible"
 
 ENTRY_COUNT=$(ipset list allowed-domains | grep -cE '^[0-9]' || echo 0)
 log "Firewall active — $ENTRY_COUNT IP(s) whitelisted, IPv4 + IPv6 locked down"
+
+# Mark initialization complete to prevent re-invocation
+touch "$LOCK_FILE"


### PR DESCRIPTION
## Summary

- **GitHub Pages leak**: The `/22` CIDR ranges from GitHub's meta API (`185.199.108.0/22`, `192.30.252.0/22`) also cover GitHub Pages IPs, letting agents reach any Pages-hosted site (e.g. `boehs.com`, `*.github.io`). These ranges are now excluded; domains that need IPs in those ranges (`raw.githubusercontent.com`, `objects.githubusercontent.com`) are resolved via DNS instead.
- **sudo iptables escape**: Agents had passwordless sudo access to `/usr/sbin/iptables`, allowing them to add their own firewall rules and bypass restrictions. Removed from sudoers; the capability check now goes through `init-firewall.sh --check`.
- **Proxy IP mismatch on Docker Desktop for Mac**: The firewall used the container gateway IP (`172.17.0.1`) for proxy rules, but `host.docker.internal` resolves to a different IP (`192.168.65.x`) on Docker Desktop. Now resolves the actual proxy hostname via `getent`.

## Test plan

- [x] `boehs.com` — blocked (GitHub Pages, HTTP 000)
- [x] `ericboehs.github.io` — blocked (GitHub Pages, HTTP 000)
- [x] `google.com` / `example.com` — blocked (not whitelisted)
- [x] `github.com` — allowed (200)
- [x] `api.github.com` — allowed (200)
- [x] `raw.githubusercontent.com` — allowed (301)
- [x] `registry.npmjs.org` / `rubygems.org` — allowed (200)
- [x] `host.docker.internal:4141` (proxy) — allowed (200)
- [x] Agent bypass via `sudo iptables` — blocked (password required)
- [x] Agent bypass via `iptables` / `ipset` / `ip route` — blocked (permission denied)

### Known limitation

GitHub Pages and `raw.githubusercontent.com` share the same CDN. A determined agent can connect to the allowed `.133` IPs and send `Host: boehs.com` to fetch Pages content — but this requires writing custom LD_PRELOAD C code, a MITM proxy, and self-signed certificates. IP-based firewalling cannot prevent CDN-level routing tricks; a domain-filtering HTTP proxy would be needed to fully close this gap.